### PR TITLE
Docs: bring README and CHANGELOG up to date with what ships

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ Migrations/
 # JetBrains Rider
 .idea/
 .idea_modules/
+
+# Working directories
+@*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,64 @@ All notable changes to the WitRPC project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.3.0] - 2025-01-XX
+## [2.3.3] - 2026-04-23
+
+### Fixed
+
+- **Empty or undeserializable payloads crashed the client.** `WitClient` threw
+  `WitException("Received empty message")` when a transport handed it an empty
+  buffer, which tore down the receive loop instead of skipping the frame. Empty
+  payloads, and payloads that do not deserialize into a `WitMessage`, are now logged
+  and ignored. WebSocket client and server transports no longer forward empty frames
+  in the first place. Adds `WitClientIncomingPayloadTests`.
+
+## [2.3.2] - 2026-04-22
+
+### Added
+
+#### Blazor WebAssembly client
+
+- **New Package**: `OutWit.Communication.Client.Blazor` - a channel factory for
+  Blazor WebAssembly clients. `IChannelFactory` / `ChannelFactory` with
+  `ChannelFactoryOptions`, `ChannelReconnectOptions`, `ChannelRetryOptions` and
+  `ChannelTokenProvider`, plus `ServiceCollectionExtensions` for one-line
+  registration. Browser-side encryption runs through `EncryptorClientWeb` over the
+  Web Crypto API, so no BouncyCastle assembly is needed in the browser.
+- The channel factory accepts a custom URL, and exposes a `BufferSize` option.
+
+#### Dependency injection surface reworked
+
+- New types on both sides: `IConfigureWitClient` / `ConfigureWitClient` and
+  `IConfigureWitServer` / `ConfigureWitServer`, `IWitClientFactory` /
+  `IWitServerFactory`, the builder contexts `WitClientBuilderContext` and
+  `WitServerBuilderContext` with their extension methods, and
+  `WitClientHostedServiceOptions` / `WitServerHostedServiceOptions`.
+- The registration extensions were simplified around those contexts and a redundant
+  overload was removed.
+
+### Fixed
+
+- **Stale frames after a disconnect.** `WitServer` now resolves the connection
+  through `TryGetConnection` and ignores messages addressed to a disconnected or
+  unknown client, instead of processing them against missing state. Initialization,
+  authorization and encryption now take the resolved connection explicitly.
+- **Transport lifecycle across a restart.** `ITransportServerFactory` is now
+  `IDisposable`, and the memory-mapped file, named pipe, TCP and WebSocket server
+  transport factories release their listeners on disposal. `WitServer.Dispose` became
+  idempotent: it unsubscribes from the transport factory, the request processor and
+  the discovery server, and stops listening. Adds `TransportFactoryLifecycleTests`.
+- Crypto interop fix in the Blazor client.
+- Server-side service resolution from the DI container.
+
+## [2.3.1] - 2026-01-25
+
+### Changed
+
+- Licensing and packaging metadata across every package: `PackageLicenseExpression`
+  set to `Apache-2.0`, a `NOTICE` file added to each package, and `LICENSE`, README
+  and csproj package metadata refreshed. No functional changes.
+
+## [2.3.0] - 2025-12-09
 
 ### Added
 
@@ -221,6 +278,6 @@ app.MapHealthChecks("/health");
 
 ---
 
-## [2.2.0] - Previous Release
+## [2.2.0] - 2025-11-14
 
 *See repository history for previous changes.*

--- a/InterProcess/OutWit.InterProcess.Agent/README.md
+++ b/InterProcess/OutWit.InterProcess.Agent/README.md
@@ -1,131 +1,65 @@
-﻿# OutWit.InterProcess.Agent
+# OutWit.InterProcess.Agent
 
-**Agent-side library for running WitRPC services in an isolated process.** This package is used inside the **external process (agent)** to host a WitRPC server and register services that the host process can call. OutWit.InterProcess.Agent works in tandem with the Host package to set up communication channels automatically, so you can focus on implementing your service. It’s essentially the “server-side” counterpart in the inter-process model: you include this in the child process that performs the work, such as a legacy component or a plugin that runs out-of-process.
+Agent-side package of the WitRPC inter-process suite. Install it in the executable that runs as a child process (the agent) of a host application. The agent hosts a WitRPC service; this package supplies the application base that handles the lifecycle around it: parsing startup parameters, monitoring the parent process, and shutting down when abandoned.
 
-## Overview
+## Install
 
-**OutWit.InterProcess.Agent** is part of the WitRPC inter-process communication suite and is meant to be **included in the application that runs as the agent** (the separate process). Its primary role is to start up a WitRPC service inside the agent process and connect it to the host. The library abstracts away the complexity of listening for a connection from the host and synchronizing the setup.
-
-Key characteristics of the Agent package:
-
--   **WitRPC Server Initialization:** Under the hood, this package uses the WitRPC server functionality (from OutWit.Communication.Server) to create a server in the agent process that will serve the host’s requests. It takes care of binding the server to the correct transport/endpoint that the host will use to connect, so you typically don’t have to manually specify ports or pipe names.
-    
--   **Service Registration:** You provide the service implementation (one or more objects implementing your service interfaces) to the agent’s startup method. The agent announces these services to the host. From that point, the host can obtain proxies and invoke the services remotely. The agent can host multiple services if needed, similar to how a single server can expose many interfaces.
-    
--   **Automatic Handshake with Host:** The Agent package and the Host package have a protocol to handshake. For example, when the host launches the agent process, it might pass connection info via command-line arguments or environment variables. OutWit.InterProcess.Agent reads those and immediately starts the server accordingly. This means as a developer you often don’t need to write any networking setup code in the agent – just call the run method and your service is live.
-    
--   **Minimal Footprint:** The agent process can be a lightweight console application or Windows service that does one job. With this library, that app only needs a few lines of boilerplate to start the WitRPC service and then it can focus on the actual logic (e.g., calling the legacy API or performing an isolated computation).
-    
-
-By using OutWit.InterProcess.Agent, you ensure your out-of-process service adheres to the WitRPC protocol and can be easily consumed by any WitRPC client (in this case, the host). This package **fits into the WitRPC ecosystem** as the counterpart to the usual server library, but specialized for scenarios where the server lives in a separate process launched by a host.
-
-## Installation
-
-Install **OutWit.InterProcess.Agent** in the project that will be compiled as your external agent process:
-
-```shell
-Install-Package OutWit.InterProcess.Agent
+```bash
+dotnet add package OutWit.InterProcess.Agent
 ```
 
-Requirements: .NET 6.0 (Windows) or higher, and typically you’ll also reference any WitRPC transport packages needed for your scenario (though in many cases, the default transport is set up automatically by the Host <-> Agent handshake). The Agent package will bring in **OutWit.InterProcess** (base logic) and **OutWit.Communication.Server** (WitRPC server core) as dependencies.
+Brings in `OutWit.InterProcess` (shared model). Add the WitRPC server transport package matching the host's client side, and reference the shared contracts assembly.
 
-> **Tip:** Your agent application could be a simple console app that references this package along with your interfaces and implementations. Ensure that the interface definitions used by the agent and host are the same (usually shared via a common library) so that the WitRPC proxy and server have identical contracts.
+## The agent pattern
 
-## Usage: Hosting a Service in an Agent Process
-
-Using OutWit.InterProcess.Agent is straightforward. In your agent program’s entry point, you will initialize the WitRPC server and register your service instance(s). The library likely provides a helper to do this in one call. While the exact API can vary, a typical pattern is:
-
-1.  **Implement the Service:** Define the interface (if not already defined) and implement it in a class. For example, `IExampleService` and `ExampleService` as in the earlier scenario.
-    
-2.  **Start the Agent:** In the `Main` method of the agent application, call the provided **agent startup** method to register your services and begin listening for the host’s connection. This could be a method like `WitProcessAgent.Run(...)` or similar. You pass in the service instance or a factory lambda.
-    
-3.  **Keep Running:** Once started, the agent should generally keep running to serve incoming calls from the host. If it’s a console app, you might just wait on the WitRPC server to shut down or block the main thread (the Agent library might handle this for you internally).
-    
-
-**Example (Agent Program):**
+An agent does three things: reads its startup parameters from the command line, starts a WitRPC server on the address the host assigned, and lets the lifecycle machinery watch the parent.
 
 ```csharp
-using OutWit.InterProcess.Agent;
-using MySharedInterfaces;  // contains IExampleService
+using OutWit.Common.CommandLine;
+using OutWit.Communication.Server;
+using OutWit.InterProcess.Model;
 
-class Program
+[STAThread]
+static void Main(string[] args)
 {
-    static void Main(string[] args)
-    {
-        // Launch the WitRPC server in this process and register the ExampleService.
-        WitProcessAgent.Run(() => new ExampleService());
+    var parameters = args.DeserializeCommandLine<AgentStartupParameters>();
 
-        // The agent is now running. It will remain active, listening for the host 
-        // to connect and invoke IExampleService methods. Typically no further code 
-        // is needed here unless you want to log or handle shutdown signals.
-    }
+    var server = WitServerBuilder.Build(options =>
+    {
+        options.WithService(new ProcessingService());
+        options.WithNamedPipe(parameters.Address);   // address supplied by the host
+        options.WithJson();
+    });
+    server.StartWaitingForConnection();
+
+    var app = new AgentApplication(parameters);
+    app.Run();
 }
 ```
 
-In this example, `WitProcessAgent.Run` (hypothetically) does the heavy lifting:
+The host passes `AgentStartupParameters` (address, parent process id, timeout, shutdown policy) as serialized command-line arguments; `DeserializeCommandLine` reconstructs them. The service implementation and server setup are ordinary WitRPC, with the transport address taken from the parameters instead of hard-coded.
 
--   It reads any connection parameters (possibly passed via `args` or environment variables by the host).
-    
--   It builds a WitRPC server with the chosen transport (e.g., a unique named pipe or shared memory file) matching the host.
-    
--   It instantiates your `ExampleService` (via the lambda) and makes it available to the host under the `IExampleService` interface.
-    
--   It likely blocks the main thread or runs an event loop to keep the process alive while waiting for calls. You don’t need to loop or poll manually – once `Run` is called, your service is serving.
-    
+## What AgentApplication handles
 
-At this point, whenever the host process connects (using OutWit.InterProcess.Host), it will handshake with this agent. The host’s calls into `IExampleService` will be routed to this `ExampleService` instance inside the agent process. Likewise, if `ExampleService` raises an event, the Agent library will forward that to any subscribed proxies in the host process.
+- **Parent monitoring.** When `ShutdownOnParentProcessExited` is set, the agent watches the host's process id and terminates itself when the host disappears, including a host crash. No orphaned processes.
+- **Startup timeout.** An agent that receives no connection within `Timeout` shuts down on its own instead of lingering.
+- **Timeout extension.** Call `ResetTimeout()` during legitimate long-running work so the watchdog does not mistake activity for abandonment.
 
-## Use Cases
+## Windows and WPF
 
-OutWit.InterProcess.Agent is useful in any scenario where you want a .NET component to run out-of-process and communicate with a primary application. Some specific cases:
+`AgentApplication` derives from `System.Windows.Application`, so an agent project using it must set `<UseWPF>true</UseWPF>` and targets Windows (`net6.0-windows` through `net10.0-windows`). This suits the common case of agents living alongside desktop hosts.
 
--   **Legacy Component Wrapper:** Suppose you have an old 32-bit COM object or library that cannot be loaded into a 64-bit process. You can write a small agent that calls this component (e.g., via P/Invoke or COM Interop) and expose a modern interface (`ILegacyWrapper`) via WitRPC. The host launches this agent when needed and interacts through the interface, insulating the main app from the legacy code’s quirks.
-    
--   **Crash Isolation:** If you expect a certain module to be unstable (perhaps it uses unsafe code or third-party libraries that occasionally crash), running it as an agent means a crash won’t take down your main application. For example, a graphics processing library that isn’t fully reliable could be used in an agent. The host detects if the agent stops responding and can restart it if necessary.
-    
--   **Security Sandbox:** Run sensitive operations with lower privileges. For instance, if the agent process is launched with a restricted Windows user account or with a specific AppContainer, it can perform only the allowed tasks. The host (with higher privileges) remains protected. The Agent package facilitates communication back to the host so results can be returned despite the isolation.
-    
--   **Multiple Service Instances:** You could have several different agent executables for different tasks (or even spawn multiple instances of the same agent for load balancing). Each agent uses OutWit.InterProcess.Agent to register its service, and the host keeps track of connections to each. This is useful for parallel processing or modular architectures where each feature/plugin runs independently.
-    
+For a cross-platform or plain console agent, keep the same structure and supply your own entry point: parse `AgentStartupParameters` from the command line, start the server, monitor `ParentProcessId` yourself, and drive the startup timeout with `System.Threading.Timer`. The host side works identically with either variant.
 
-In all these cases, the Agent library ensures that writing the agent process code is nearly as simple as writing an in-process service. You focus on your service logic, and the networking/IPC is handled by WitRPC.
+## What the host sees
 
-## Integration Details
+The host launches this executable through `HostManager<TService>` (from [OutWit.InterProcess.Host](https://www.nuget.org/packages/OutWit.InterProcess.Host/)), connects to the address it assigned, and receives a typed proxy for the service. Method calls execute in the agent; events the service raises arrive at the host's subscribers.
 
-When using OutWit.InterProcess.Agent, you’re leveraging the standard WitRPC server capabilities in an out-of-process setting:
+A complete working host/agent pair lives in the repository: [Examples/InterProcess](https://github.com/dmitrat/WitRPC/tree/main/Examples/InterProcess).
 
--   The agent’s **WitRPC server** supports all the usual features: encryption, compression, custom serializers, etc. If the host expects an encrypted connection (e.g., using a pre-shared token or certificate), the agent can be configured to use the same `WithEncryption()` or `WithAccessToken(...)` options so that security is enforced on both ends.
-    
--   **Supported Transports:** The choice of transport for host-agent communication is typically made by the host (which might default to a local IPC transport). The agent will use whatever transport info is provided. For example, if using Named Pipes, the host might generate a unique pipe name and the agent will open a server on that name. If using a Memory-Mapped File, the host provides the map name and size, and the agent attaches to it. All this is negotiated through the Agent/Host libraries automatically.
-    
--   **WitRPC Protocol Compliance:** Because the agent uses the official WitRPC server internally, it speaks the same protocol that any WitRPC client understands. In theory, this means you could even connect to an OutWit.InterProcess.Agent process using a regular OutWit.Communication.Client (if you knew the connection details), not just the special Host launcher. This underscores that the agent is a normal WitRPC server just started in a different manner.
-    
--   **Lifecycle Management:** The Agent library might provide hooks or events for things like when a host connects or disconnects. This can be useful for logging or for the agent to decide when to shut down (for instance, the agent might exit if the host disconnects and no other work is to be done). You can integrate this with your application’s logging or monitoring. Similarly, the agent could be configured to accept only a single host connection for security (since in typical scenarios, the host launched it so no other client should attach).
-    
+## Links
 
-**Note:** OutWit.InterProcess.Agent is generally not used standalone; it expects a coordinating host. If you run the agent application by itself, it will likely start a server and wait indefinitely (with no effect until a host connects). Ensure that you launch the agent via the intended Host APIs or at least provide the necessary startup info so it knows how to function.
-
-## Further Documentation
-
-To learn more about WitRPC and advanced agent configurations, visit [witrpc.io](https://witrpc.io/). The documentation contains guides on topics like custom security setups, troubleshooting connections, and optimizing performance for inter-process calls. Understanding the basics of WitRPC (events, serialization, etc.) will also help in making the most of the Host/Agent architecture.
-
-## License
-
-Licensed under the Apache License, Version 2.0. See `LICENSE`.
-
-## Attribution (optional)
-
-If you use OutWit.InterProcess.Agent in a product, a mention is appreciated (but not required), for example:
-"Powered by WitRPC (https://witrpc.io/)".
-
-## Trademark / Project name
-
-"WitRPC" and the WitRPC logo are used to identify the official project by Dmitry Ratner.
-
-You may:
-- refer to the project name in a factual way (e.g., "built with WitRPC");
-- use the name to indicate compatibility (e.g., "WitRPC-compatible").
-
-You may not:
-- use "WitRPC" as the name of a fork or a derived product in a way that implies it is the official project;
-- use the WitRPC logo to promote forks or derived products without permission.
+- Documentation: https://witrpc.io/
+- Repository: https://github.com/dmitrat/WitRPC
+- Host-side package: [OutWit.InterProcess.Host](https://www.nuget.org/packages/OutWit.InterProcess.Host/)
+- License: Apache 2.0

--- a/InterProcess/OutWit.InterProcess.Host/README.md
+++ b/InterProcess/OutWit.InterProcess.Host/README.md
@@ -1,123 +1,83 @@
-﻿
 # OutWit.InterProcess.Host
 
-**Host-side library for launching and communicating with out-of-process WitRPC services.** This package is used in the **main (host) application** to spawn external processes and connect to the services they host. OutWit.InterProcess.Host provides the client-side coordination for inter-process calls: you launch an agent process (which uses the Agent library) and immediately get a proxy to use its services. It simplifies running components in separate processes while treating them almost like local objects in your code.
+Host-side package of the WitRPC inter-process suite. Install it in the main application to launch agent processes and communicate with the services they host through typed WitRPC proxies. The package covers the full cycle: starting the agent executable, connecting to it, handing you the proxy, and shutting the agent down.
 
-## Overview
+## Install
 
-**OutWit.InterProcess.Host** is the counterpart to the Agent package and is typically referenced by the primary application that needs to utilize out-of-process services. Its responsibilities and features include:
-
--   **Process Launching:** It can start the external process for you, given an executable path or configuration. This might involve creating a new Process with the correct parameters (for example, pointing it to use a particular communication channel). The Host library abstracts the details of using `System.Diagnostics.Process` or other OS-specific calls – you just tell it what to run.
-    
--   **Handshake & Connection:** Once the agent process starts, the Host library establishes a WitRPC connection to it. This includes negotiating a transport (often a local IPC mechanism like a named pipe) and making sure the agent’s WitRPC server is ready. The Host will wait for the agent to signal that it’s up and running, thereby handling timing issues of startup.
-    
--   **Dynamic Proxy Retrieval:** After a successful connection, OutWit.InterProcess.Host gives you a **proxy instance** implementing the service interface that the agent provides. This uses WitRPC’s dynamic proxy ability – the same feature used for remote network calls. From the developer’s perspective, calling `host.Launch<IService>` (or similar) returns an `IService` object that you can immediately use to call methods. Under the hood, those calls are being transmitted to the other process.
-    
--   **Process Management:** The Host library may also manage the lifetime of the agent process. For instance, it could offer methods to gracefully shut down the agent or restart it. It might also detect if the agent process exits unexpectedly (so your host app can react). In some cases, the host can be configured to automatically kill the agent process when the host itself exits, to avoid orphan processes.
-    
-By using OutWit.InterProcess.Host, you can integrate external processes into your application architecture without having to write manual IPC code or deal with raw process control beyond the basics. This library ensures the **out-of-process services are as easy to consume as in-process ones**, fulfilling WitRPC’s goal of natural, object-oriented communication across boundaries.
-
-## Installation
-
-Install **OutWit.InterProcess.Host** in your main application project (the one that will launch and talk to the external service processes):
-
-```shell
-Install-Package OutWit.InterProcess.Host
+```bash
+dotnet add package OutWit.InterProcess.Host
 ```
 
-This will also install **OutWit.InterProcess** (base) and **OutWit.Communication.Client** (the WitRPC client core) as dependencies. The Host package targets .NET 6.0 on Windows. Ensure that your host and agent are built against compatible versions of WitRPC so their communications align.
+Brings in `OutWit.InterProcess` (shared model) and the WitRPC client core. The host and agent projects should share a contracts assembly with the service interfaces, as in any WitRPC setup.
 
-Typically, you'll also have a reference to the interface definitions that the host and agent share (so the host knows about `IExampleService`, for example). These interfaces can be in a common assembly referenced by both projects.
+## Getting started
 
-## Usage: Launching an Agent and Getting a Service Proxy
-
-Using OutWit.InterProcess.Host usually boils down to one main action: **launching an agent process and retrieving the service proxy**. The library likely provides a simple API to do this. The general pattern is:
-
-1.  **Prepare the agent executable:** Decide which process you are going to launch. This could be an external `.exe` file (perhaps the output of your agent project). Make sure the agent is accessible (e.g., include it in your deployment or have a known path).
-    
-2.  **Call the Host launch method:** Use the Host library’s API to start the agent. You will specify the service interface you expect the agent to provide, and the path to the agent program. There may be additional options (for example, working directory, command-line args, etc., if needed).
-    
-3.  **Receive the service interface proxy:** The launch method will return an implementation of the interface that actually forwards calls to the agent. You can immediately call methods on it or subscribe to its events. From here on, usage of the service is identical to a local object – the Host library and WitRPC handle the communication.
-    
-
-**Example (Host side):**
+`HostManager<TService>` manages agents for one service type. Construct it with client options (transport, serializer, security), the path to the agent executable, and a process startup timeout; each `CreateClient` call launches one agent process and returns it connected and initialized:
 
 ```csharp
+using OutWit.Communication.Client;
 using OutWit.InterProcess.Host;
-using MySharedInterfaces;  // e.g., contains IExampleService
 
-// Launch the agent process (ExampleAgent.exe) and get a proxy to IExampleService
-IExampleService service = WitProcessHost.Launch<IExampleService>("ExampleAgent.exe");
+var options = new WitClientBuilderOptions();
+options.WithNamedPipe($"MyApp_{Guid.NewGuid():N}");   // unique per-agent address
+options.WithJson();
 
-// Use the service proxy as if it's local
-string result = service.ProcessData("input-data");
-Console.WriteLine($"Agent returned: {result}");
+var manager = new HostManager<IProcessingService>(
+    options,
+    "ProcessingAgent.exe",
+    processTimeout: TimeSpan.FromSeconds(30));
 
-// You can also subscribe to events published by the remote service
-service.ProgressChanged += percent => Console.WriteLine($"Progress: {percent}%");
+IAgent<IProcessingService> agent = await manager.CreateClient(TimeSpan.FromSeconds(10));
+
+// The typed proxy: calls run in the agent process, events come back
+IProcessingService service = agent.Service!;
+service.ProgressChanged += p => Console.WriteLine($"Progress: {p}%");
+var result = await service.ProcessAsync(inputPath);
+
+// Done with this worker
+agent.Shutdown();
 ```
 
-In this hypothetical code, `WitProcessHost.Launch<T>` starts the process `ExampleAgent.exe`, negotiates a connection, and returns an object that implements `IExampleService`. When you call `service.ProcessData`, the call is sent over to the agent process, executed by the real `ExampleService`, and the result is sent back. If `IExampleService` has events (like `ProgressChanged` in the snippet above), the agent can raise those and the Host library will forward them to your event handler in the host process.
+The transport address configured in the options is handed to the agent at launch, so both sides meet on the same channel without any configuration inside the agent.
 
-A few notes on this process:
+## The agent handle
 
--   The first call to `Launch` might take a short moment, as it’s starting a process and setting up IPC. Once connected, calls are typically fast (especially using in-memory or pipe transport).
-    
--   If the agent fails to start or connect (for example, if the file path is wrong or the agent crashes on startup), the Host library should throw an exception or return an error. Be prepared to handle such cases (e.g., log the error or notify the user).
-    
--   The Host can launch multiple agents by calling `Launch` multiple times (perhaps with different executables or the same executable with different arguments). Each call would yield a different service proxy connected to a different process.
-    
+`CreateClient` returns `IAgent<TService>`:
 
-## Scenarios and Use Cases
+- `Service` — the WitRPC proxy for the contract; methods, return values, and events all work across the process boundary.
+- `IsInitialized` — whether the agent is connected and ready.
+- `Initialized` / `Disposed` — lifecycle events. Subscribe to `Disposed` to react to agent crashes: relaunch, degrade, or report, while the host keeps running.
+- `Stop()` — graceful disconnect; `Shutdown()` — terminate the agent process.
 
-OutWit.InterProcess.Host empowers several architectural choices in your application:
+The manager tracks its agents (`GetAgent(id)`, `ShutdownAgent(id)`) and disposes them with itself.
 
--   **Modular Plugins:** Suppose your app supports plugins that might be unreliable or need to be sandboxed. You can deploy each plugin as a separate executable (implementing a known plugin interface). The host uses the Host library to load each plugin process on demand and get a proxy to call its functions. If a plugin misbehaves, you can terminate that process without affecting the rest of the app.
-    
--   **Large Computations in Isolation:** If you have a long-running computation or background task that is CPU-intensive, you might run it in another process to keep the UI responsive. The host launches a “worker” process (agent) to do the computation. Progress and results come back via WitRPC events and calls, keeping the main UI thread free. This also takes advantage of multiple CPU cores (each process can run on a different core).
-    
--   **Inter-process GUI/Service separation:** In some designs, you have a Windows GUI app and a Windows service or console doing backend work. Using OutWit.InterProcess.Host, the GUI (host) could start the backend (agent) if it’s not already running and then communicate via WitRPC. This is an alternative to using something like WCF with an external service – instead, you directly spawn and connect, which can simplify deployment (no separate service install required, if you go with on-demand launching).
-    
--   **Switching Execution Context:** If your application sometimes needs to perform an operation in a different bitness or with certain libraries loaded, you can swap it to an external process. For example, an application might by default do everything in-proc, but if a certain feature is activated that requires a 32-bit environment, the Host can launch a 32-bit agent for that feature alone. The rest of the app remains 64-bit. This targeted approach can reduce complexity compared to running the entire app in 32-bit just for one component.
-    
+## Lower-level launching
 
-In all these scenarios, OutWit.InterProcess.Host’s value is in making the *communication and management of those processes trivial*. You don’t have to manually set up named pipe servers or socket listeners, or worry about serialization – you call `Launch` and then use a strongly-typed interface.
+`HostUtils.RunAgent` starts an agent process directly, without the manager, when you need custom control over the lifecycle:
 
-## Integration and Advanced Features
+```csharp
+Process? process = HostUtils.RunAgent(
+    pathToAgent: "ProcessingAgent.exe",
+    address: pipeName,
+    timeout: TimeSpan.FromSeconds(30),
+    shutdownOnParentProcessExited: true);
+```
 
-OutWit.InterProcess.Host is built on the WitRPC client framework, meaning it inherits all client-side capabilities:
+An overload accepts a custom serializable parameters object for agents with their own startup contract.
 
--   It utilizes the **OutWit.Communication.Client** under the hood. This means you can configure things like serialization format or timeouts if needed. For example, if you want to use MessagePack instead of JSON for transferring large data to the agent (to improve speed), you could configure that in the launch options if such an API exists. Similarly, you might set a timeout for certain calls – if the agent doesn’t respond in, say, 10 seconds, the proxy call could throw a timeout exception.
-    
--   **Security considerations:** Because the host and agent run on the same machine, one might assume security is less of a concern. However, if your agent deals with sensitive operations, you can still enforce encryption or require an authentication token for the connection. WitRPC supports token-based auth and encryption as options. The Host library can pass a token to the agent on startup, and the agent will validate it. This ensures that a malicious process can’t impersonate your agent and hijack the connection.
-    
--   **Resource cleanup:** The Host library likely provides a way to dispose of or stop the connection and the process. For instance, when your application is closing, you might want to shut down all agent processes. This could be as simple as disposing the proxy or calling a special method to signal the agent to exit. WitRPC proxies are disposable objects, so disposing one might also terminate the underlying connection. Check the documentation for the recommended cleanup pattern (e.g., the host might call something like `host.Close()` or the agent might exit on its own when the host disconnects).
-    
--   **Cross-platform note:** Currently, OutWit.InterProcess.Host is targeted at Windows. It uses transports like named pipes or memory files which are also available on Linux/macOS, but the process launching and some integration aspects might be Windows-specific. Future versions may expand cross-platform support. If you are targeting other OSes, ensure to test the behavior or consult the docs for any limitations.
-    
-## Further Resources
+## Choosing a transport
 
-For more information on using the Host and Agent pattern with WitRPC, refer to the official documentation on [witrpc.io](https://witrpc.io/). You'll find examples, troubleshooting tips (for example, if an agent fails to launch or connect), and guidance on performance tuning (such as when to use memory-mapped files vs. pipes for IPC). The WitRPC community and documentation can also provide patterns for scenarios like gracefully updating an agent or sharing data between host and agent beyond RPC calls.
+Named pipes are the default choice for command-and-control traffic; memory-mapped files win for large data volumes between the host and a single agent. Both stay on the machine. Any WitRPC client transport package works: install the one matching the agent's server side.
 
-By understanding both OutWit.InterProcess.Host and Agent, you can architect flexible applications that take full advantage of process isolation while still communicating effectively and safely.
+## Safety nets
 
-## License
+Agents launched with `ShutdownOnParentProcessExited` terminate themselves when the host process disappears, including a host crash, so no orphaned processes accumulate. An agent that receives no connection within its startup timeout also exits on its own.
 
-Licensed under the Apache License, Version 2.0. See `LICENSE`.
+A complete working example (a WPF host managing a pool of agents) lives in the repository: [Examples/InterProcess](https://github.com/dmitrat/WitRPC/tree/main/Examples/InterProcess).
 
-## Attribution (optional)
+## Links
 
-If you use OutWit.InterProcess.Host in a product, a mention is appreciated (but not required), for example:
-"Powered by WitRPC (https://witrpc.io/)".
-
-## Trademark / Project name
-
-"WitRPC" and the WitRPC logo are used to identify the official project by Dmitry Ratner.
-
-You may:
-- refer to the project name in a factual way (e.g., "built with WitRPC");
-- use the name to indicate compatibility (e.g., "WitRPC-compatible").
-
-You may not:
-- use "WitRPC" as the name of a fork or a derived product in a way that implies it is the official project;
-- use the WitRPC logo to promote forks or derived products without permission.
+- Documentation: https://witrpc.io/
+- Repository: https://github.com/dmitrat/WitRPC
+- Agent-side package: [OutWit.InterProcess.Agent](https://www.nuget.org/packages/OutWit.InterProcess.Agent/)
+- License: Apache 2.0

--- a/InterProcess/OutWit.InterProcess/README.md
+++ b/InterProcess/OutWit.InterProcess/README.md
@@ -1,132 +1,65 @@
-﻿
-
 # OutWit.InterProcess
 
-**Inter-process communication base logic for the WitRPC framework.** This package provides the foundation for launching and communicating with external processes within the WitRPC ecosystem. It enables .NET applications to call services in separate processes as if they were local, using WitRPC’s dynamic proxies and transports. OutWit.InterProcess is ideal for scenarios where you need to run parts of your application in isolation or in a different environment (e.g. a 32-bit legacy component from a 64-bit host). It works seamlessly with the rest of WitRPC, allowing event-driven, secure communication between processes just like standard in-process or network calls.
+Base package of the WitRPC inter-process suite. It defines the model shared by the host and agent sides of the Host/Agent pattern: a main application (the host) launches child processes (agents), each agent hosts a WitRPC service, and the host talks to it through an ordinary typed proxy.
 
-## Overview
+You will normally install one of the two role packages, which bring this one in as a dependency:
 
-**OutWit.InterProcess** extends the WitRPC framework’s capabilities to **inter-process communication** on a single machine. WitRPC is a modern .NET client-server communication framework focused on simplicity and robust real-time RPC. With OutWit.InterProcess, you can leverage WitRPC to communicate across process boundaries. The same **dynamic proxy mechanism** of WitRPC is used here – the client in one process gets a proxy object implementing your interface, and the server in another process hosts the actual service object. Method calls, property accesses, and even events all traverse the process boundary seamlessly, so your code looks like regular method calls even though work is happening in another process.
+- **[OutWit.InterProcess.Host](https://www.nuget.org/packages/OutWit.InterProcess.Host/)** — for the main application: launches agents and returns service proxies.
+- **[OutWit.InterProcess.Agent](https://www.nuget.org/packages/OutWit.InterProcess.Agent/)** — for the agent executable: entry-point base with parent monitoring and startup timeout.
 
-This package serves as the **foundation** for out-of-process calls:
+Reference this package directly only when building custom inter-process logic on top of the shared model.
 
--   **Core Launch/Connect Logic:** It handles the low-level details of starting processes and establishing communication channels between them.
-    
--   **Transport Agnostic:** Communication can occur over any supported WitRPC transport (e.g. Named Pipes or Memory-Mapped Files) optimized for inter-process use. By default, fast IPC transports are used for efficiency on the local machine.
-    
--   **Transparent Integration:** Once connected, the remote service behaves like a local object. You can subscribe to events or call methods without worrying about serialization or message passing – WitRPC handles it under the hood.
-    
--   **Cross-Architecture Support:** Because communication is transport-based (not via in-process calls), you can connect a 64-bit process to a 32-bit process reliably. This is crucial for hosting legacy 32-bit libraries in a separate helper process while the main app remains 64-bit.
-    
-In summary, OutWit.InterProcess is the building block that makes out-of-process plugins or services possible in the WitRPC ecosystem, providing a robust alternative to technologies like COM out-of-proc servers or custom socket solutions, with far less boilerplate.
+## Install
 
-## Installation
-
-You can install **OutWit.InterProcess** via NuGet:
-
-```shell
-Install-Package OutWit.InterProcess
+```bash
+dotnet add package OutWit.InterProcess
 ```
 
-This package targets **.NET 6.0+** and will pull in the required WitRPC core libraries. In many cases, you won’t install this package directly – instead you will use the higher-level **Host** or **Agent** packages (which depend on OutWit.InterProcess) in your host and agent projects respectively. However, if you need to build custom inter-process logic, you can reference this base package.
+## What it contains
 
-## Basic Usage
+**`AgentStartupParameters`** — the launch contract between host and agent, passed to the agent process as serialized command-line arguments:
 
-Typically, you will use OutWit.InterProcess through the **Host** and **Agent** components (see their documentation below). For advanced scenarios, if you are using OutWit.InterProcess directly, you would perform these general steps:
+| Property | Meaning |
+|---|---|
+| `Address` | Transport address the agent's WitRPC server must listen on |
+| `ParentProcessId` | Host process id, monitored by the agent |
+| `Timeout` | How long the agent waits for a connection before shutting itself down |
+| `ShutdownOnParentProcessExited` | Whether the agent terminates when the host process disappears |
 
-1.  **Prepare the Agent Process:** Develop a separate application (or module) that includes your service implementation and uses **OutWit.InterProcess.Agent** to await connections. For example, the agent might call a run method to host a service (see *OutWit.InterProcess.Agent* section for details).
-    
-2.  **Launch from Host:** In the main application, use **OutWit.InterProcess.Host** to spawn the external process and connect to it. The Host APIs will start the process (e.g. launching the agent executable) and establish a WitRPC connection over an IPC transport.
-    
-3.  **Obtain Service Proxy:** After launching, the host gets a proxy for the remote service interface. You can then call methods on this proxy just like a normal object. WitRPC handles routing those calls to the external process.
-    
+An agent reads the parameters with `args.DeserializeCommandLine<AgentStartupParameters>()` (from `OutWit.Common.CommandLine`).
 
-**Example:** Suppose you have an interface `IExampleService` that you want to run in another process. You would create an agent program to implement and host this service, and then launch it from your main app:
+**`IAgent<TService>`** — the host-side handle for one running agent:
 
--   **Agent side (external process)** – register and start the service:
-    
-    ```csharp
-    // Agent process code
-    using OutWit.InterProcess.Agent;
-    using OutWit.Communication.Server;  // WitRPC server base
-    
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            // Start the agent server with an instance of ExampleService
-            WitProcessAgent.Run(() => new ExampleService());
-            // The agent will now host IExampleService and wait for connections from the host.
-        }
-    }
-    ```
-    
--   **Host side (main process)** – launch agent and get the service proxy:
-    
-    ```csharp
-    // Host process code
-    using OutWit.InterProcess.Host;
-    using OutWit.Communication.Client;  // WitRPC client base
-    
-    // Launch the external process and connect to IExampleService
-    IExampleService service = WitProcessHost.Launch<IExampleService>("ExampleAgent.exe");
-    
-    // Now 'service' is a live proxy to the remote ExampleService.
-    bool started = service.StartProcessing();
-    Console.WriteLine($"Processing started: {started}");
-    ```
-    
-In this pseudo-code, `WitProcessAgent.Run(...)` initializes the agent’s WitRPC server with your service, and `WitProcessHost.Launch<IFace>(...)` on the host launches the agent executable and returns a proxy implementing the interface `IFace` (here `IExampleService`). The actual API calls in the library may differ, but the concept remains: one call to set up the agent, one call to launch from the host, and then use the interface directly.
-    
-## Use Cases
+```csharp
+public interface IAgent<out TService> : IDisposable where TService : class
+{
+    event AgentEventHandler Initialized;
+    event AgentEventHandler Disposed;
 
-OutWit.InterProcess is useful whenever you need to isolate or separate parts of your application into different processes while still having them communicate seamlessly:
+    Task<bool> Initialize(TimeSpan timeout);
+    Task Stop();          // graceful disconnect
+    void Shutdown();      // terminate the agent process
 
--   **Running 32-bit legacy components:** If your main app is 64-bit but you depend on a 32-bit library or COM object, you can run that component in a small 32-bit agent process. OutWit.InterProcess will carry out all calls via IPC (e.g. through named pipes), so the architecture mismatch is no longer a problem.
-    
--   **Isolating unreliable or resource-intensive modules:** For components that might crash or leak memory, keeping them in a separate process can protect the stability of the main application. For example, a plug-in executing untrusted scripts could be run in an external sandbox process. If it crashes, the host remains unaffected and can optionally restart the agent.
-    
--   **Parallel or multi-process workloads:** You can distribute work across multiple processes on the same machine. Each process can host a service (with its own CPU/memory resources) and the main process can coordinate them. WitRPC’s event-driven calls make it straightforward to manage results and progress updates from each process.
-    
--   **Security and permissions:** In scenarios where a certain operation needs elevated permissions or a different user context, you could launch an agent process with those credentials. The host communicates through WitRPC, and you avoid running the entire application with higher privileges.
-    
-In all these cases, OutWit.InterProcess lets you maintain a **clean separation**: the host and agent don’t share memory – they interact only through well-defined service interfaces, making the system more modular and robust.
+    TService? Service { get; }   // the typed WitRPC proxy
+    bool IsInitialized { get; }
+}
+```
 
-## Integration with WitRPC Ecosystem
+**`IAgentManager<TService>`** — the contract for managing a set of agents (`CreateClient`, `GetAgent`, `ShutdownAgent`), implemented by `HostManager<TService>` in the Host package.
 
-OutWit.InterProcess is a first-class part of the WitRPC framework. It builds on the same **OutWit.Communication** core libraries for serialization, networking, and security:
+## How the pieces fit
 
--   You can use any **transport** supported by WitRPC for the host-agent connection. The library is typically configured to use fast local transports like memory-mapped files or named pipes by default, but the programming model doesn’t change based on transport. Developers simply call `Launch` or `Run` methods and the underlying transport is abstracted away.
-    
--   Full support for **encryption and authorization:** If your WitRPC setup uses end-to-end encryption or token-based auth, those can be enabled in inter-process communications as well. For example, you could protect the channel between host and agent with AES/RSA encryption, just as you would for a network connection, to ensure even local IPC traffic is secure.
-    
--   **Consistent serialization:** The default JSON serialization (or MessagePack, if configured) is used for data exchange, so complex objects, callbacks, and exceptions all serialize across processes the same way they do across network endpoints. This means your data contracts and DTOs require no special treatment for IPC.
-    
--   **Common API patterns:** OutWit.InterProcess reuses the WitRPC builder patterns and interfaces. Developers already familiar with `WitClientBuilder` and `WitServerBuilder` will find the inter-process host/agent setup quite intuitive. The learning curve is minimal – you’re still working with service interfaces and lambda-based configuration of options.
-    
-By using OutWit.InterProcess alongside the rest of WitRPC, you ensure that *all* parts of your distributed system (whether in other processes or on other machines) follow the same conventions. You can, for instance, have a mix where some services are loaded in-proc, some in local helper processes, and others on remote servers – all invoked in a uniform way.
+1. The host prepares `AgentStartupParameters` and starts the agent executable with them.
+2. The agent parses the parameters, starts a WitRPC server on `Address`, and begins monitoring `ParentProcessId`.
+3. The host connects a WitRPC client to the same address and obtains the typed proxy.
+4. From there the connection is ordinary WitRPC: methods, return values, and events across the process boundary.
 
-## Further Documentation
+If the host exits, the agent notices and terminates itself, so no orphaned processes remain; an agent that receives no connection within `Timeout` also shuts down on its own.
 
-For more details on the WitRPC framework and advanced usage of inter-process features, visit the official WitRPC documentation site at  [witrpc.io](https://witrpc.io/). There you will find guides, additional examples, and reference documentation covering topics such as custom transports, security, and performance tuning within the WitRPC/OutWit ecosystem
+A complete working host/agent pair lives in the repository: [Examples/InterProcess](https://github.com/dmitrat/WitRPC/tree/main/Examples/InterProcess).
 
-## License
+## Links
 
-Licensed under the Apache License, Version 2.0. See `LICENSE`.
-
-## Attribution (optional)
-
-If you use OutWit.InterProcess in a product, a mention is appreciated (but not required), for example:
-"Powered by WitRPC (https://witrpc.io/)".
-
-## Trademark / Project name
-
-"WitRPC" and the WitRPC logo are used to identify the official project by Dmitry Ratner.
-
-You may:
-- refer to the project name in a factual way (e.g., "built with WitRPC");
-- use the name to indicate compatibility (e.g., "WitRPC-compatible").
-
-You may not:
-- use "WitRPC" as the name of a fork or a derived product in a way that implies it is the official project;
-- use the WitRPC logo to promote forks or derived products without permission.
+- Documentation: https://witrpc.io/
+- Repository: https://github.com/dmitrat/WitRPC
+- License: Apache 2.0

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ WitRPC is a modern API for client-server communication designed to simplify deve
   - Auto-reconnection with configurable retry strategies
   - Retry policies for failed calls
 - **Health Checks**: Built-in health check support for ASP.NET Core applications
+- **Service Discovery**: Servers announce themselves over UDP multicast and clients find them on the local network, with no hard-coded addresses.
 - **Cross-Platform Support**: Works across all .NET-supported platforms, including Blazor WebAssembly.
 - **Extensibility**: Default implementations for serialization, encryption, and authorization can be replaced with custom ones.
 
@@ -66,6 +67,7 @@ WitRPC is a modern API for client-server communication designed to simplify deve
 | `OutWit.Communication.Client.HealthChecks` | Health checks for client | [![NuGet](https://img.shields.io/nuget/v/OutWit.Communication.Client.HealthChecks.svg)](https://www.nuget.org/packages/OutWit.Communication.Client.HealthChecks/) |
 | `OutWit.Communication.Client.Encryption.BouncyCastle` | Cross-platform encryption (Blazor WASM) | [![NuGet](https://img.shields.io/nuget/v/OutWit.Communication.Client.Encryption.BouncyCastle.svg)](https://www.nuget.org/packages/OutWit.Communication.Client.Encryption.BouncyCastle/) |
 | `OutWit.Communication.Server.Encryption.BouncyCastle` | Cross-platform encryption | [![NuGet](https://img.shields.io/nuget/v/OutWit.Communication.Server.Encryption.BouncyCastle.svg)](https://www.nuget.org/packages/OutWit.Communication.Server.Encryption.BouncyCastle/) |
+| `OutWit.Communication.Client.Blazor` | Channel factory for Blazor WebAssembly clients | [![NuGet](https://img.shields.io/nuget/v/OutWit.Communication.Client.Blazor.svg)](https://www.nuget.org/packages/OutWit.Communication.Client.Blazor/) |
 
 ### InterProcess
 | Package | Description | NuGet |
@@ -194,7 +196,26 @@ var orderService = client.GetService<IOrderService>();
 
 ### Blazor WebAssembly Support
 
-Use BouncyCastle encryption for Blazor WebAssembly clients:
+`OutWit.Communication.Client.Blazor` is the shortest route: it registers a channel
+factory in the container, and its encryption runs on the browser's Web Crypto API, so
+no extra crypto package is needed in the browser.
+
+```csharp
+// Program.cs of the Blazor WebAssembly app
+using OutWit.Communication.Client.Blazor;
+
+builder.Services.AddWitRpcChannel();          // defaults: encryption, reconnect, retry
+
+// or with options
+builder.Services.AddWitRpcChannel(options =>
+{
+    options.ApiPath = "api";                  // WebSocket endpoint path
+    options.TimeoutSeconds = 15;
+});
+```
+
+Alternatively, configure a client by hand with BouncyCastle encryption, which also
+works in WebAssembly:
 
 ```csharp
 // Client (Blazor WebAssembly)


### PR DESCRIPTION
The docs stopped tracking the code at 2.3.0; three releases and a package have shipped since.

## CHANGELOG

- **2.3.1, 2.3.2 and 2.3.3 were missing entirely** while published on NuGet.
- The version-to-commit mapping is not inferred from dates alone: `<Version>` was read out of `Communication/OutWit.Communication/OutWit.Communication.csproj` at each commit, and the dates are the packages' published timestamps.

| Commit | Date | `<Version>` |
|---|---|---|
| `0842296` | 2026-01-25 | 2.3.1 |
| `8b8501c` | 2026-04-22 | 2.3.2 |
| `cb4a68d` | 2026-04-23 | 2.3.3 |

- 2.3.0 was dated `2025-01-XX` (placeholder) and 2.2.0 `Previous Release`; both now carry their real dates — 2025-12-09 and 2025-11-14.

## README

- `OutWit.Communication.Client.Blazor` was absent from the package table although it ships since 2.3.2. All 22 packages are now listed.
- The Blazor section showed only the manual BouncyCastle route; it now leads with `AddWitRpcChannel`, checked against `ServiceCollectionExtensions` in the package.
- Service discovery was missing from the feature list despite being in the code (`DiscoveryClient`/`DiscoveryServer` plus per-transport `DiscoveryUtils`).

## InterProcess READMEs

All three documented **an API that does not exist**: `WitProcessHost.Launch<T>()` and `WitProcessAgent.Run()` appear nowhere in the source, under a disclaimer reading *"The actual API calls in the library may differ, but the concept remains"*. Neither `HostManager` nor `AgentApplication` was mentioned in any markdown file in the repository.

Replaced with the prepared text built on the real entry points: `HostManager`, `HostAgent`, `AgentApplication`, `AgentStartupParameters`, `HostUtils`.

## Also

`@*/` added to `.gitignore` — `@`-prefixed folders are working directories.

Note that these READMEs are packed into the NuGet packages, so the corrected text reaches nuget.org on the next publish of the affected packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)